### PR TITLE
console logging fix

### DIFF
--- a/wpt.js
+++ b/wpt.js
@@ -125,7 +125,7 @@ const wptRun = (options, ngrok) => {
           return console.log(`-------------------------------------------------
 
 Aerate Results for ${options.tests[index].name}:
-${table.toString()}`);
+${table}`);
         }
         return console.log(`Test failed, reason: ${datum.error.message}`);
       });

--- a/wpt.js
+++ b/wpt.js
@@ -124,7 +124,8 @@ const wptRun = (options, ngrok) => {
           });
           return console.log(`-------------------------------------------------
 
-          Aerate Results for ${options.tests[index].name}: ${table.toString}`);
+Aerate Results for ${options.tests[index].name}:
+${table.toString()}`);
         }
         return console.log(`Test failed, reason: ${datum.error.message}`);
       });


### PR DESCRIPTION
**What**:

Fixes console logging bug introduced with [prettier](https://github.com/fourkitchens/aerate/pull/11). 

**How**:

Brings back `toString` function, formats according to what looks best in console

**To test**:

* [ ] Add this to the bottom of `.index.js` replacing the API KEY with your own:

```
aerate({
  key: 'WPT_API_KEY',
  tests: [
    {
      name: 'Google.com',
      url: 'http://google.com',
      type: 'homepage'
    },
    {
      name: 'Yahoo.com',
      url: 'https://www.yahoo.com/',
      type: 'homepage'
    },
    {
      name: 'Bing.com',
      url: 'https://www.bing.com/',
      type: 'homepage'
    }
  ],
  count: 1,
  ui: true
});
```
* [ ] Verify console results look correct again
